### PR TITLE
Disable entities while parsing XML

### DIFF
--- a/ner.py
+++ b/ner.py
@@ -781,7 +781,8 @@ def ocr_to_dict(url):
 
     parser = lxml.etree.XMLParser(ns_clean=False,
                                   recover=True,
-                                  encoding='utf-8')
+                                  encoding='utf-8',
+                                  resolve_entities=False)
 
     xml = lxml.etree.fromstring(text.encode(), parser=parser)
 


### PR DESCRIPTION
If an attacker supplies a url returning malicious XML content, they may be able to leak internal information such as files, and/or cause a denial of service. 

Entrypoint:
https://github.com/KBNLresearch/multiNER/blob/c0440948057afc6e3d6b4903a7c05e666b94a3bc/ner.py#L657

Getting into `ocr_to_dict`:
https://github.com/KBNLresearch/multiNER/blob/c0440948057afc6e3d6b4903a7c05e666b94a3bc/ner.py#L676

User-controlled URL request:
https://github.com/KBNLresearch/multiNER/blob/c0440948057afc6e3d6b4903a7c05e666b94a3bc/ner.py#L770

Vulnerable parser declaration:
https://github.com/KBNLresearch/multiNER/blob/c0440948057afc6e3d6b4903a7c05e666b94a3bc/ner.py#L782-L784

Sink:
https://github.com/KBNLresearch/multiNER/blob/c0440948057afc6e3d6b4903a7c05e666b94a3bc/ner.py#L786

More information:
* [MITRE](https://cwe.mitre.org/data/definitions/611.html)
* [OWASP vulnerability description](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing)
* [OWASP guidance on parsing xml files](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#python)